### PR TITLE
Update entities selectel_domains_v2 for work with domains-go 1.0.2. Added optional field project_id for entities selectel_domains_v2. Fix work with optional fields.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/selectel/craas-go v0.3.0
 	github.com/selectel/dbaas-go v0.9.0
-	github.com/selectel/domains-go v1.0.1
+	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/go-selvpcclient/v3 v3.1.1
 	github.com/selectel/mks-go v0.12.0
 	github.com/stretchr/testify v1.8.4

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/selectel/craas-go v0.3.0
 	github.com/selectel/dbaas-go v0.9.0
-	github.com/selectel/domains-go v1.0.0
+	github.com/selectel/domains-go v1.0.1
 	github.com/selectel/go-selvpcclient/v3 v3.1.1
 	github.com/selectel/mks-go v0.12.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -155,10 +155,12 @@ github.com/selectel/dbaas-go v0.9.0 h1:IAmiyxkRtfLZg1JUdIhcsE5jpdBvsZibPCqyhB+yV
 github.com/selectel/dbaas-go v0.9.0/go.mod h1:8D945oFzpx94v08zIb4s1bRTPCdPoNVnBu4umMYFJrQ=
 github.com/selectel/domains-go v0.5.0 h1:RCrWY/9KHVtfdA+X8M+DDzsjILxFChhY70HnJEu1Y2U=
 github.com/selectel/domains-go v0.5.0/go.mod h1:AhXhwyMSTkpEWFiBLUvzFP76W+WN+ZblwmjLJLt7y58=
-github.com/selectel/go-selvpcclient/v3 v3.1.1 h1:C1q2LqqosiapoLpnGITGmysg0YCSQYDo2Gh69CioevM=
-github.com/selectel/go-selvpcclient/v3 v3.1.1/go.mod h1:NM7IXhh1IzqZ88DOw1Qc5Ez3tULLViXo95l5+rKPuyQ=
 github.com/selectel/domains-go v1.0.0 h1:F3itzB+wdPAg9j6l+mVJFANC6hyShqBa9VykYfV+row=
 github.com/selectel/domains-go v1.0.0/go.mod h1:SugRKfq4sTpnOHquslCpzda72wV8u0cMBHx0C0l+bzA=
+github.com/selectel/domains-go v1.0.1 h1:Dau3uVlAXA3iFpeUQq2ld/aOlc8bzwdAXdVPGMwCD7Q=
+github.com/selectel/domains-go v1.0.1/go.mod h1:SugRKfq4sTpnOHquslCpzda72wV8u0cMBHx0C0l+bzA=
+github.com/selectel/go-selvpcclient/v3 v3.1.1 h1:C1q2LqqosiapoLpnGITGmysg0YCSQYDo2Gh69CioevM=
+github.com/selectel/go-selvpcclient/v3 v3.1.1/go.mod h1:NM7IXhh1IzqZ88DOw1Qc5Ez3tULLViXo95l5+rKPuyQ=
 github.com/selectel/mks-go v0.12.0 h1:nLWHK8BXkhFlXvjFqf7WRrdAfvmrOhQzDSLx7BGa6aM=
 github.com/selectel/mks-go v0.12.0/go.mod h1:FcFqF3WvZIhztyAt1+ZySKf0zWmCEvg9e2gRwxVyQOw=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -153,12 +153,10 @@ github.com/selectel/craas-go v0.3.0 h1:tXiw3LNN+ZVV0wZdeBBXX6u8kMuA5PV/5W1uYqV0y
 github.com/selectel/craas-go v0.3.0/go.mod h1:9RAUn9PdMITP4I3GAade6v2hjB2j3lo3J2dDlG5SLYE=
 github.com/selectel/dbaas-go v0.9.0 h1:IAmiyxkRtfLZg1JUdIhcsE5jpdBvsZibPCqyhB+yV30=
 github.com/selectel/dbaas-go v0.9.0/go.mod h1:8D945oFzpx94v08zIb4s1bRTPCdPoNVnBu4umMYFJrQ=
-github.com/selectel/domains-go v0.5.0 h1:RCrWY/9KHVtfdA+X8M+DDzsjILxFChhY70HnJEu1Y2U=
-github.com/selectel/domains-go v0.5.0/go.mod h1:AhXhwyMSTkpEWFiBLUvzFP76W+WN+ZblwmjLJLt7y58=
-github.com/selectel/domains-go v1.0.0 h1:F3itzB+wdPAg9j6l+mVJFANC6hyShqBa9VykYfV+row=
-github.com/selectel/domains-go v1.0.0/go.mod h1:SugRKfq4sTpnOHquslCpzda72wV8u0cMBHx0C0l+bzA=
 github.com/selectel/domains-go v1.0.1 h1:Dau3uVlAXA3iFpeUQq2ld/aOlc8bzwdAXdVPGMwCD7Q=
 github.com/selectel/domains-go v1.0.1/go.mod h1:SugRKfq4sTpnOHquslCpzda72wV8u0cMBHx0C0l+bzA=
+github.com/selectel/domains-go v1.0.2 h1:Si6iGaMnTFJxwiJVI50DOdZnwcxc87kqaWrVQYW0a4U=
+github.com/selectel/domains-go v1.0.2/go.mod h1:SugRKfq4sTpnOHquslCpzda72wV8u0cMBHx0C0l+bzA=
 github.com/selectel/go-selvpcclient/v3 v3.1.1 h1:C1q2LqqosiapoLpnGITGmysg0YCSQYDo2Gh69CioevM=
 github.com/selectel/go-selvpcclient/v3 v3.1.1/go.mod h1:NM7IXhh1IzqZ88DOw1Qc5Ez3tULLViXo95l5+rKPuyQ=
 github.com/selectel/mks-go v0.12.0 h1:nLWHK8BXkhFlXvjFqf7WRrdAfvmrOhQzDSLx7BGa6aM=

--- a/selectel/data_source_selectel_domains_rrset_v2.go
+++ b/selectel/data_source_selectel_domains_rrset_v2.go
@@ -23,13 +23,17 @@ func dataSourceDomainsRrsetV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 			"zone_id": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"type": {
+			"project_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"comment": {
 				Type:     schema.TypeString,
@@ -64,7 +68,7 @@ func dataSourceDomainsRrsetV2() *schema.Resource {
 }
 
 func dataSourceDomainsRrsetV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getDomainsV2Client(meta)
+	client, err := getDomainsV2Client(d, meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/selectel/data_source_selectel_domains_zone_v2.go
+++ b/selectel/data_source_selectel_domains_zone_v2.go
@@ -22,6 +22,11 @@ func dataSourceDomainsZoneV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"comment": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -46,10 +51,6 @@ func dataSourceDomainsZoneV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"project_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"disabled": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -59,7 +60,7 @@ func dataSourceDomainsZoneV2() *schema.Resource {
 }
 
 func dataSourceDomainsZoneV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := getDomainsV2Client(meta)
+	client, err := getDomainsV2Client(d, meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/selectel/data_source_selectel_domains_zone_v2_test.go
+++ b/selectel/data_source_selectel_domains_zone_v2_test.go
@@ -41,9 +41,7 @@ func testAccDomainsZoneV2Exists(name string) resource.TestCheckFunc {
 		if zoneID == "" {
 			return errors.New("zone ID not set in tf state")
 		}
-
-		meta := testAccProvider.Meta()
-		client, err := getDomainsV2Client(meta)
+		client, err := getDomainsV2ClientTest(rs, testAccProvider)
 		if err != nil {
 			return err
 		}

--- a/selectel/domains_v2.go
+++ b/selectel/domains_v2.go
@@ -8,18 +8,19 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	domainsV2 "github.com/selectel/domains-go/pkg/v2"
 )
 
 var ErrProjectIDNotSetupForDNSV2 = errors.New("env variable SEL_PROJECT_ID or variable project_id must be set for the dns v2")
 
-func getDomainsV2Client(meta interface{}) (domainsV2.DNSClient[domainsV2.Zone, domainsV2.RRSet], error) {
+func getDomainsV2Client(d *schema.ResourceData, meta interface{}) (domainsV2.DNSClient[domainsV2.Zone, domainsV2.RRSet], error) {
 	config := meta.(*Config)
-	if config.ProjectID == "" {
-		return nil, ErrProjectIDNotSetupForDNSV2
+	projectID, err := getProjectIDFromResourceOrConfig(d, config)
+	if err != nil {
+		return nil, fmt.Errorf("can't get projectID for domains v2: %w", err)
 	}
-
-	selvpcClient, err := config.GetSelVPCClientWithProjectScope(config.ProjectID)
+	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
 	if err != nil {
 		return nil, fmt.Errorf("can't get selvpc client for domains v2: %w", err)
 	}
@@ -33,6 +34,18 @@ func getDomainsV2Client(meta interface{}) (domainsV2.DNSClient[domainsV2.Zone, d
 	domainsClient := domainsV2.NewClient(defaultApiURL, httpClient, hdrs)
 
 	return domainsClient, nil
+}
+
+func getProjectIDFromResourceOrConfig(d *schema.ResourceData, config *Config) (string, error) {
+	projectID := config.ProjectID
+	if v, ok := d.GetOk("project_id"); ok {
+		projectID = v.(string)
+	}
+	if projectID == "" {
+		return "", ErrProjectIDNotSetupForDNSV2
+	}
+
+	return projectID, nil
 }
 
 func getZoneByName(ctx context.Context, client domainsV2.DNSClient[domainsV2.Zone, domainsV2.RRSet], zoneName string) (*domainsV2.Zone, error) {

--- a/selectel/resource_selectel_domains_rrset_v2.go
+++ b/selectel/resource_selectel_domains_rrset_v2.go
@@ -40,7 +40,7 @@ func resourceDomainsRrsetV2() *schema.Resource {
 			},
 			"comment": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
 			},
 			"managed_by": {
 				Type:     schema.TypeString,

--- a/selectel/resource_selectel_domains_rrset_v2_test.go
+++ b/selectel/resource_selectel_domains_rrset_v2_test.go
@@ -71,12 +71,6 @@ func testAccDomainsRrsetV2Basic(resourceRrsetName, rrsetName, rrsetType, rrsetCo
 }
 
 func testAccCheckDomainsV2RrsetDestroy(s *terraform.State) error {
-	meta := testAccProvider.Meta()
-	client, err := getDomainsV2Client(meta)
-	if err != nil {
-		return err
-	}
-
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -87,7 +81,10 @@ func testAccCheckDomainsV2RrsetDestroy(s *terraform.State) error {
 
 		zoneID := rs.Primary.Attributes["zone_id"]
 		rrsetID := rs.Primary.ID
-
+		client, err := getDomainsV2ClientTest(rs, testAccProvider)
+		if err != nil {
+			return err
+		}
 		_, err = client.GetRRSet(ctx, zoneID, rrsetID)
 		if err == nil {
 			return errors.New("rrset still exists")

--- a/selectel/resource_selectel_domains_zone_v2_test.go
+++ b/selectel/resource_selectel_domains_zone_v2_test.go
@@ -38,12 +38,6 @@ func testAccDomainsZoneV2Basic(resourceName, zoneName string) string {
 }
 
 func testAccCheckDomainsV2ZoneDestroy(s *terraform.State) error {
-	meta := testAccProvider.Meta()
-	client, err := getDomainsV2Client(meta)
-	if err != nil {
-		return err
-	}
-
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -52,7 +46,10 @@ func testAccCheckDomainsV2ZoneDestroy(s *terraform.State) error {
 		}
 
 		zoneID := rs.Primary.ID
-
+		client, err := getDomainsV2ClientTest(rs, testAccProvider)
+		if err != nil {
+			return err
+		}
 		_, err = client.GetZone(ctx, zoneID, nil)
 		if err == nil {
 			return errors.New("domain still exists")


### PR DESCRIPTION
Обновил версию библиотеки domains-go до 1.0.2, где были изменения названия полей и фикс функции обновления состояния.
Добавил у `selectel_domains_zone_v2` и `selectel_domains_rrset_v2` необязательное поле project_id.
Пофиксил баги работы с опциональными полями